### PR TITLE
Fix Temperature Issue for ExtraTemps Sensor

### DIFF
--- a/custom_components/davis_vantage/client.py
+++ b/custom_components/davis_vantage/client.py
@@ -29,6 +29,7 @@ from .utils import (
     get_solar_rad,
     get_uv,
     get_wind_rose,
+    get_temp_add_sensor,
 )
 from .const import (
     BEAUFORT_DESCRIPTION_STATES,
@@ -410,6 +411,13 @@ class DavisVantageClient:
         data["StormStartDate"] = self.strtodate(data["StormStartDate"])
         data["SunRise"] = self.strtotime(data["SunRise"])
         data["SunSet"] = self.strtotime(data["SunSet"])
+
+        for key, value in list(data.items()):
+            if key.startswith(("ExtraTemps", "LeafTemps", "SoilTemps")):
+                if value is not None:
+                    data[key] = get_temp_add_sensor(value)
+
+
         self.correct_rain_values(data)
 
     def correct_rain_values(self, data: dict[str, Any]):

--- a/custom_components/davis_vantage/client.py
+++ b/custom_components/davis_vantage/client.py
@@ -412,11 +412,16 @@ class DavisVantageClient:
         data["SunRise"] = self.strtotime(data["SunRise"])
         data["SunSet"] = self.strtotime(data["SunSet"])
 
-        for key, value in list(data.items()):
-            if key.startswith(("ExtraTemps", "LeafTemps", "SoilTemps")):
-                if value is not None:
-                    data[key] = get_temp_add_sensor(value)
-
+        for i in range(1, 8):
+            temp_key = f"ExtraTemps{i:02d}"
+            if temp_key in data and data[temp_key] is not None:
+                data[temp_key] = get_temp_add_sensor(data[temp_key])
+        
+        for typekey in ("LeafTemps", "SoilTemps"):
+            for i in range(1, 4):
+                temp_key = f"{typekey}{i:02d}"
+                if temp_key in data and data[temp_key] is not None:
+                    data[temp_key] = get_temp_add_sensor(data[temp_key])
 
         self.correct_rain_values(data)
 

--- a/custom_components/davis_vantage/utils.py
+++ b/custom_components/davis_vantage/utils.py
@@ -158,6 +158,9 @@ def get_uv(value: int) -> float:
 def get_solar_rad(value: int) -> float:
     return value
 
+def get_temp_add_sensor(value: int) -> int:
+    return value - 90
+
 def calc_dew_point(temperature_f: float, humidity: float) -> float:
     temperature_c = convert_to_celcius(temperature_f)
     a = math.log(humidity / 100) + (17.62 * temperature_c / (243.12 + temperature_c))


### PR DESCRIPTION

## Summary

Decode Davis extra, soil, and leaf temperatures as unsigned bytes and apply the documented 90°F offset.

## Reason

The Davis serial protocol stores these temperature values as unsigned bytes with a 90°F offset. 

Without applying this offset, Home Assistant reports temperatures that are 90°F too high, as described in the associated issue.

## Changes

- Apply `raw_value - 90`
- Add or update tests

Fixes Issue (https://github.com/MarcoGos/davis_vantage/issues/35)
